### PR TITLE
feat: fetch pacts from Google Apps Script API endpoint

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import "./App.css";
 import Map from "./components/Map";
+import Button from "./components/Button";
 import usePacts from "./hooks/usePacts";
 import classNames from "classnames";
 import { logInfo } from "./util/log";
 
 function App() {
-  const { pacts } = usePacts();
+  const { pacts, loading, error, retry } = usePacts();
   const isUrlGithub = window.location.hostname.includes("github.io");
   const isUrlLocalhost = window.location.hostname.includes("localhost");
 
@@ -18,6 +19,27 @@ function App() {
       "h-full": !isUrlGithub && !isUrlLocalhost,
     }
   );
+
+  if (loading) {
+    return (
+      <div className={containerClass + " flex items-center justify-center"}>
+        <p className="text-on-background">Laddar pakter...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={containerClass + " flex flex-col items-center justify-center gap-4 p-4"}>
+        <p className="text-on-background text-center">
+          Kunde inte ladda pakter: {error}
+        </p>
+        <Button variant="primary" onClick={retry}>
+          Försök igen
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <div className={containerClass}>

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,3 +1,8 @@
+const PACTS_API_URL =
+  "https://script.google.com/macros/s/AKfycbxScmyuGxNzwnNiRUer_ijA5jPsO30CkoDvBfyRTmZyj_WXg89pqcqTyY7jImbMDwGa/exec";
+
 export const config = {
   googleApiKey: import.meta.env.VITE_GOOGLE_API_KEY,
+  pactsApiUrl:
+    import.meta.env.VITE_PACTS_API_URL ?? PACTS_API_URL,
 } as const; 


### PR DESCRIPTION
- Replace static JSON import with fetch() to Google Apps Script endpoint
- Add loading state ("Laddar pakter...") and error state with retry button
- Add config.pactsApiUrl (overridable via VITE_PACTS_API_URL)